### PR TITLE
Support Contao 4.13+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
   "require": {
     "php": "^8.1",
     "ext-json": "*",
-    "contao/core-bundle": "^5.1",
+    "contao/core-bundle": "^4.13 || ^5.0",
     "symfony/config": "^5.4 || ^6.0",
     "symfony/console": "^5.4 || ^6.0",
     "symfony/dependency-injection": "^5.4 || ^6.0",


### PR DESCRIPTION
I think it would make sense to have one version that support the latest LTS as well as the current Contao versions. Since 4.13 contains (almost) all relevant changes that Contao 5 requires, this shouldn't be a problem to achieve 😊 