### PR TITLE
Fix PHP warning on initializeSystem

### DIFF
--- a/src/EventListener/Contao/InitializeSystem.php
+++ b/src/EventListener/Contao/InitializeSystem.php
@@ -86,7 +86,7 @@ class InitializeSystem
             return;
         }
 
-        $name = Input::post('name');
+        $name = (string) Input::post('name');
         if (!\preg_match('/_row[0-9]*_/i', $name)) {
             return;
         }


### PR DESCRIPTION
I get this error regularely in my system:

```
ErrorException
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated
```
