### PR TITLE
Fix the missing support for save_callback being a function

### DIFF
--- a/src/Contao/Widgets/MultiColumnWizard.php
+++ b/src/Contao/Widgets/MultiColumnWizard.php
@@ -677,13 +677,22 @@ class MultiColumnWizard extends Widget
                 // Save callback
                 if (isset($arrField['save_callback']) && is_array($arrField['save_callback'])) {
                     foreach ($arrField['save_callback'] as $callback) {
-                        $this->import($callback[0]);
+                        if (is_array($callback)) {
+                            $this->import($callback[0]);
 
-                        try {
-                            $varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this);
-                        } catch (\Exception $exception) {
-                            $objWidget->class = 'error';
-                            $objWidget->addError($exception->getMessage());
+                            try {
+                                $varValue = $this->{$callback[0]}->{$callback[1]}($varValue, $this);
+                            } catch (\Exception $exception) {
+                                $objWidget->class = 'error';
+                                $objWidget->addError($exception->getMessage());
+                            }
+                        } elseif (\is_callable($callback)) {
+                            try {
+                                $varValue = $callback($varValue, $this);
+                            } catch (\Exception $exception) {
+                                $objWidget->class = 'error';
+                                $objWidget->addError($exception->getMessage());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Right now the callbacks inside `save_callback` must be provided as arrays:

```php
'save_callback' => [
    ['class1', 'method1'],
    ['class2', 'method2'],
],
```

However, Contao also supports functions. This pull request fixes this, so functions can be provided as well:

```php
'save_callback' => [
    ['class1', 'method1'],
    static function($value) {
        return $value;
    }
],
```