### PR TITLE
Do not patch `Backend.openModelSelector` more than once

### DIFF
--- a/src/Resources/public/js/multicolumnwizard_be_src.js
+++ b/src/Resources/public/js/multicolumnwizard_be_src.js
@@ -897,7 +897,9 @@ MultiColumnWizard.addOperationClickCallback('down', MultiColumnWizard.downClick)
  * Patch Contao Core to support file & page tree
  */
 (function(Backend) {
-    if(!Backend) return;
+    if(!Backend || Backend.__mcwOpenModalSelector) return;
+    Backend.__mcwOpenModalSelector = true;
+    
     Backend.openModalSelectorOriginal = Backend.openModalSelector;
     Backend.openModalSelector = function(options) {
         Backend.openModalSelectorOriginal(options);


### PR DESCRIPTION
In Contao versions with Turbo the `Backend.openModelSelector` function might get patched more than once, as the code is run every time a request is made.

This can lead to the following error:
```
Uncaught RangeError: Maximum call stack size exceeded
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:902:41)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
    at Backend.openModalSelector [as openModalSelectorOriginal] (multicolumnwizard_be_src.js?v=43e7ba85:903:17)
```

This PR fixes the problem simply by adding a check if the function was already patched.